### PR TITLE
refer 3.6.1 zip

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -22,5 +22,5 @@ papp.out.7z = false
 atf.id = android-studio-ide
 atf.win64.filename = ${atf.id}-win64
 atf.win64.ext = .zip
-atf.win64.url = https://dl.google.com/dl/android/studio/ide-zips/3.5.3.0/android-studio-ide-191.6010548-windows.zip
+atf.win64.url = https://dl.google.com/dl/android/studio/ide-zips/3.6.1.0/android-studio-ide-192.6241897-windows.zip
 atf.win64.assertextract = android-studio/bin/studio64.exe


### PR DESCRIPTION
Currently, IDE shows old version in the about dialog.
It seems to be different of portable package and included zip versions.